### PR TITLE
enable finding passwords in subfolders & case insensitiveness for pass

### DIFF
--- a/pass.py
+++ b/pass.py
@@ -27,9 +27,10 @@ elif op == 'QUERY':
     query = query.strip()
 
     names = []
-    for p in sorted(Path.home().glob('.password-store/*.gpg')):
-        name = p.name[:-len('.gpg')]
-        if name.find(query) != -1:
+    for p in sorted(Path.home().glob('.password-store/**/*.gpg')):
+        full_relative_name = p.relative_to(os.path.join(Path.home()), '.password-store')
+        name, ext = os.path.splitext(full_relative_name)
+        if name.lower().find(query.lower()) != -1:
             names.append(name)
 
     items = []


### PR DESCRIPTION
Hello,

Pass allows us to use subfolders for our passwords for extra tidyness and I use that extensively.
However the current implementation only looks for .gpg files at the root .password-store directory.

This PR fixes that. I also added case insensitive search.

I was looking at fuzzy searching but I believe that requires https://github.com/seatgeek/fuzzywuzzy, but since you have no dependency yet I left it out.

Tested locally.